### PR TITLE
Option to disable private entitlement copying

### DIFF
--- a/AltSign/Model/ALTApplication.h
+++ b/AltSign/Model/ALTApplication.h
@@ -40,6 +40,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, copy, readonly) NSURL *fileURL;
 
+@property (nonatomic, assign) BOOL hasPrivateEntitlements;
+
 - (nullable instancetype)initWithFileURL:(NSURL *)fileURL;
 
 @end

--- a/AltSign/Signing/ALTSigner.mm
+++ b/AltSign/Signing/ALTSigner.mm
@@ -214,18 +214,20 @@ std::string CertificatesContent(ALTCertificate *altCertificate)
             [profile.data writeToURL:profileURL atomically:YES];
             
             NSString *additionalEntitlements = nil;
-            
-            NSRange commentStartRange = [app.entitlementsString rangeOfString:@"<!---><!-->"];
-            NSRange commentEndRange = [app.entitlementsString rangeOfString:@"<!-- -->"];
-            if (commentStartRange.location != NSNotFound && commentEndRange.location != NSNotFound && commentEndRange.location > commentStartRange.location)
+            if (app.hasPrivateEntitlements)
             {
-                // Most likely using private (commented out) entitlements to exploit Psychic Paper https://github.com/Siguza/psychicpaper
-                // Assume they know what they are doing and extract private entitlements to merge with profile's.
-                
-                NSRange commentRange = NSMakeRange(commentStartRange.location, (commentEndRange.location + commentEndRange.length) - commentStartRange.location);
-                NSString *commentedEntitlements = [app.entitlementsString substringWithRange:commentRange];
-                
-                additionalEntitlements = commentedEntitlements;
+                NSRange commentStartRange = [app.entitlementsString rangeOfString:@"<!---><!-->"];
+                NSRange commentEndRange = [app.entitlementsString rangeOfString:@"<!-- -->"];
+                if (commentStartRange.location != NSNotFound && commentEndRange.location != NSNotFound && commentEndRange.location > commentStartRange.location)
+                {
+                    // Most likely using private (commented out) entitlements to exploit Psychic Paper https://github.com/Siguza/psychicpaper
+                    // Assume they know what they are doing and extract private entitlements to merge with profile's.
+                    
+                    NSRange commentRange = NSMakeRange(commentStartRange.location, (commentEndRange.location + commentEndRange.length) - commentStartRange.location);
+                    NSString *commentedEntitlements = [app.entitlementsString substringWithRange:commentRange];
+                    
+                    additionalEntitlements = commentedEntitlements;
+                }
             }
             
             NSData *entitlementsData = [NSPropertyListSerialization dataWithPropertyList:profile.entitlements format:NSPropertyListXMLFormat_v1_0 options:0 error:&error];


### PR DESCRIPTION
On iOS 14, app entitlements are checked on installation. This makes it
difficult to distribute a single IPA for both < iOS 13.5 with psychic paper
and >= iOS 13.5 where the entitlements should be ignored.