### PR TITLE
Add HealthKit capability mapping

### DIFF
--- a/AltSign/Capabilities/ALTCapabilities.h
+++ b/AltSign/Capabilities/ALTCapabilities.h
@@ -18,12 +18,14 @@ extern ALTEntitlement const ALTEntitlementAppGroups;
 extern ALTEntitlement const ALTEntitlementGetTaskAllow;
 extern ALTEntitlement const ALTEntitlementTeamIdentifier;
 extern ALTEntitlement const ALTEntitlementInterAppAudio;
+extern ALTEntitlement const ALTEntitlementHealthKit;
 
 // Features
 typedef NSString *ALTFeature NS_TYPED_EXTENSIBLE_ENUM;
 extern ALTFeature const ALTFeatureGameCenter;
 extern ALTFeature const ALTFeatureAppGroups;
 extern ALTFeature const ALTFeatureInterAppAudio;
+extern ALTFeature const ALTFeatureHealthKit;
 
 _Nullable ALTEntitlement ALTEntitlementForFeature(ALTFeature feature) NS_SWIFT_NAME(ALTEntitlement.init(feature:));
 _Nullable ALTFeature ALTFeatureForEntitlement(ALTEntitlement entitlement) NS_SWIFT_NAME(ALTFeature.init(entitlement:));

--- a/AltSign/Capabilities/ALTCapabilities.m
+++ b/AltSign/Capabilities/ALTCapabilities.m
@@ -15,11 +15,13 @@ ALTEntitlement const ALTEntitlementAppGroups = @"com.apple.security.application-
 ALTEntitlement const ALTEntitlementGetTaskAllow = @"get-task-allow";
 ALTEntitlement const ALTEntitlementTeamIdentifier = @"com.apple.developer.team-identifier";
 ALTEntitlement const ALTEntitlementInterAppAudio = @"inter-app-audio";
+ALTEntitlement const ALTEntitlementHealthKit = @"com.apple.developer.healthkit";
 
 // Features
 ALTFeature const ALTFeatureGameCenter = @"gameCenter";
 ALTFeature const ALTFeatureAppGroups = @"APG3427HIY";
 ALTFeature const ALTFeatureInterAppAudio = @"IAD53UNK2F";
+ALTFeature const ALTFeatureHealthKit = @"HK421J6T7P";
 
 _Nullable ALTEntitlement ALTEntitlementForFeature(ALTFeature feature)
 {
@@ -30,6 +32,10 @@ _Nullable ALTEntitlement ALTEntitlementForFeature(ALTFeature feature)
     else if ([feature isEqualToString:ALTFeatureInterAppAudio])
     {
         return ALTEntitlementInterAppAudio;
+    }
+    else if ([feature isEqualToString:ALTFeatureHealthKit])
+    {
+        return ALTEntitlementHealthKit;
     }
     
     return nil;
@@ -44,6 +50,10 @@ _Nullable ALTFeature ALTFeatureForEntitlement(ALTEntitlement entitlement)
     else if ([entitlement isEqualToString:ALTEntitlementInterAppAudio])
     {
         return ALTFeatureInterAppAudio;
+    }
+    else if ([entitlement isEqualToString:ALTEntitlementHealthKit])
+    {
+        return ALTFeatureHealthKit;
     }
     
     return nil;


### PR DESCRIPTION
## Problem

AltStore and AltServer derive required App ID features from an app's signed entitlements. AltSign recognizes App Groups and Inter-App Audio, but not HealthKit, so `com.apple.developer.healthkit` is ignored and the regenerated provisioning profile does not authorize HealthKit.

## Fix

Map `com.apple.developer.healthkit` to Apple Developer Portal's `HK421J6T7P` feature in both directions.

Only the base Boolean entitlement is mapped. Values from secondary entitlements such as `com.apple.developer.healthkit.access` are not valid App ID feature values. The existing signer still limits the final signature to entitlements present in both the original app and regenerated profile.

Related to altstoreio/AltStore#1518.

## Testing

- AltStore unsigned iOS workspace build passes with this commit.
- Direct Clang syntax check and `git diff --check` pass.
- The existing `AltTests` target fails before execution because its unchanged `Nuke` module search path cannot be resolved.

On-device provisioning verification is still pending.
