### PR TITLE
Surface HTTP errors from GSA auth instead of a plist parse failure

### DIFF
--- a/AltSign/Apple API/ALTAppleAPI+Authentication.m
+++ b/AltSign/Apple API/ALTAppleAPI+Authentication.m
@@ -713,6 +713,21 @@ NSData *ALTCreateAppTokensChecksum(NSData *sk, NSString *adsid, NSArray<NSString
             return;
         }
         
+        // Apple's GSA endpoint occasionally responds to this request with a plain
+        // HTTP error page (e.g. 503 Service Temporarily Unavailable) instead of a
+        // plist body. Parsing that HTML as a plist below fails with a confusing,
+        // low-level "unknown tag html" / kCFPropertyListOldStyleParsingError, which
+        // gives no indication the actual problem is a transient server error. Check
+        // the status code first so that case gets a clear, actionable message.
+        NSHTTPURLResponse *httpResponse = [response isKindOfClass:[NSHTTPURLResponse class]] ? (NSHTTPURLResponse *)response : nil;
+        if (httpResponse != nil && (httpResponse.statusCode < 200 || httpResponse.statusCode >= 300))
+        {
+            NSString *localizedDescription = [NSString stringWithFormat:@"Apple's servers returned an error while authenticating (HTTP %@). Please try again later.", @(httpResponse.statusCode)];
+            NSError *error = [NSError errorWithDomain:ALTAppleAPIErrorDomain code:ALTAppleAPIErrorUnknown userInfo:@{NSLocalizedDescriptionKey: localizedDescription}];
+            completionHandler(nil, error);
+            return;
+        }
+
         NSError *parseError = nil;
         NSDictionary *responseDictionary = [NSPropertyListSerialization propertyListWithData:data options:0 format:nil error:&parseError];
         


### PR DESCRIPTION
## What

`sendAuthenticationRequestWithParameters:anisetteData:completionHandler:` in `ALTAppleAPI+Authentication.m` parses the GSA auth response body as a plist without first checking the HTTP status code. When `gsa.apple.com/grandslam/GsService2` returns a non-2xx response (observed: a plain `503 Service Temporarily Unavailable` HTML page) instead of the expected plist, that HTML gets fed straight into `NSPropertyListSerialization`, which fails with:

```
Encountered unknown tag html on line 1
Error Domain=NSCocoaErrorDomain Code=3840 kCFPropertyListOldStyleParsingError
```

That's the parser's generic "this isn't a plist" error — it gives no indication the actual cause is a transient server error on Apple's end. Users just see AltServer/AltStore report "could not sign in... the data is not in the correct format", which reads as a local/config problem and sends people chasing anisette or account issues instead of just retrying later.

## How I found it

Traced a live repro (AltServer 1.7.2, macOS 27 beta) by hooking `CFPropertyListCreateWithData` and `+[NSPropertyListSerialization propertyListWithData:options:format:error:]` in-process to capture the raw response bytes on parse failure. The captured body was:

```html
<html>
<head><title>503 Service Temporarily Unavailable</title></head>
<body>
<center><h1>503 Service Temporarily Unavailable</h1></center>
<hr><center>Apple</center>
</body>
</html>
```

with the failing call originating from `AltSign-Dynamic` via `sendAuthenticationRequestWithParameters:anisetteData:completionHandler:`, confirming the response is passed to the plist parser unconditionally.

## Fix

Check `NSHTTPURLResponse.statusCode` before attempting to parse. On a non-2xx status, return a clear `ALTAppleAPIErrorUnknown` error describing the HTTP status instead of surfacing the plist parse failure.

## Testing

Verified against the captured 503 response locally (confirmed the existing code path throws the "unknown tag html" parse error on that input, and that the new status check intercepts it before parsing). I don't have a way to build/run the full AltSign target here, so this hasn't been exercised through Xcode — flagging that for review.