### PR TITLE
Fix Apple ID sign in failing with a 3840 plist parse error (notarized line)

### DIFF
--- a/AltSign/Sources/ALTAppleAPI+Authentication.swift
+++ b/AltSign/Sources/ALTAppleAPI+Authentication.swift
@@ -257,11 +257,7 @@ private extension ALTAppleAPI
                         let verifyCodeTask = self.session.dataTask(with: request) { (data, response, error) in
                             do
                             {
-                                guard let data = data else { throw error ?? ALTAppleAPIError.unknown() }
-                                
-                                guard let responseDictionary = try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] else {
-                                    throw URLError(.badServerResponse)
-                                }
+                                let responseDictionary = try self.propertyListResponse(data: data, response: response, error: error)
                                 
                                 let errorCode = responseDictionary["ec"] as? Int ?? 0
                                 guard errorCode != 0 else { return completionHandler(.success(())) }

--- a/AltSign/Sources/ALTAppleAPI+Authentication.swift
+++ b/AltSign/Sources/ALTAppleAPI+Authentication.swift
@@ -419,8 +419,86 @@ private extension ALTAppleAPI
     }
 }
 
+private let ALTMaximumGSARetries = 5
+
 private extension ALTAppleAPI
 {
+    /// Parses a property list response from Apple, verifying the server actually sent one.
+    ///
+    /// Apple's GSA edge answers rejected requests with an HTML error page rather than a plist.
+    /// Handing that straight to PropertyListSerialization surfaces an opaque NSCocoaErrorDomain
+    /// 3840 "Encountered unknown tag html on line 1", which hides both the HTTP status and the
+    /// fact that this is a server-side failure rather than incorrect credentials.
+    func propertyListResponse(data: Data?, response: URLResponse?, error: Error?) throws -> [String: Any]
+    {
+        if let error = error { throw error }
+        guard let data = data else { throw ALTAppleAPIError.unknown() }
+        
+        let propertyList: Any
+        
+        do
+        {
+            propertyList = try PropertyListSerialization.propertyList(from: data, format: nil)
+        }
+        catch
+        {
+            throw self.badServerResponseError(data: data, response: response, underlyingError: error)
+        }
+        
+        guard let responseDictionary = propertyList as? [String: Any] else {
+            throw self.badServerResponseError(data: data, response: response, underlyingError: nil)
+        }
+        
+        return responseDictionary
+    }
+    
+    func badServerResponseError(data: Data?, response: URLResponse?, underlyingError: Error?) -> Error
+    {
+        var debugComponents = [String]()
+        
+        if let httpResponse = response as? HTTPURLResponse
+        {
+            debugComponents.append("HTTP \(httpResponse.statusCode)")
+            
+            if let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type")
+            {
+                debugComponents.append("Content-Type: \(contentType)")
+            }
+        }
+        
+        if let data = data
+        {
+            debugComponents.append("\(data.count) bytes")
+            
+            let snippet = String(decoding: data.prefix(256), as: UTF8.self)
+                .replacingOccurrences(of: "\n", with: " ")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !snippet.isEmpty
+            {
+                debugComponents.append("Body: \(snippet)")
+            }
+        }
+        
+        var userInfo = [String: Any]()
+        userInfo[NSDebugDescriptionErrorKey] = debugComponents.joined(separator: ", ")
+        
+        if let httpResponse = response as? HTTPURLResponse
+        {
+            userInfo[NSLocalizedDescriptionKey] = String(format: NSLocalizedString("Apple's servers returned an unexpected response (HTTP %ld).", comment: ""), httpResponse.statusCode)
+        }
+        else
+        {
+            userInfo[NSLocalizedDescriptionKey] = NSLocalizedString("Apple's servers returned an unexpected response.", comment: "")
+        }
+        
+        if let underlyingError = underlyingError
+        {
+            userInfo[NSUnderlyingErrorKey] = underlyingError
+        }
+        
+        return NSError(domain: NSURLErrorDomain, code: NSURLErrorBadServerResponse, userInfo: userInfo)
+    }
+    
     func sendAuthenticationRequest(parameters requestParameters: [String: Any], anisetteData: ALTAnisetteData, completionHandler: @escaping (Result<[String: Any], Error>) -> Void)
     {
         do
@@ -446,15 +524,37 @@ private extension ALTAppleAPI
             request.httpBody = bodyData
             httpHeaders.forEach { request.addValue($0.value, forHTTPHeaderField: $0.key) }
             
-            let dataTask = self.session.dataTask(with: request) { (data, response, error) in
+            var attempt = 0
+            
+            func send()
+            {
+            // Apple's GSA edge keeps a connection pinned to a backend node, and once that node
+            // starts failing every subsequent request on the same connection returns 5xx and never
+            // recovers. Retrying over the shared session therefore just repeats the same failure,
+            // so give each attempt its own session to force a new connection.
+            let attemptSession = URLSession(configuration: .ephemeral)
+            
+            let dataTask = attemptSession.dataTask(with: request) { (data, response, error) in
+                attemptSession.finishTasksAndInvalidate()
+                
+                // A 5xx means the request was never processed, so retrying is safe.
+                if let httpResponse = response as? HTTPURLResponse, (500...599).contains(httpResponse.statusCode), attempt < ALTMaximumGSARetries - 1
+                {
+                    attempt += 1
+                    
+                    let delay = min(pow(2.0, Double(attempt - 1)), 8.0)
+                    DispatchQueue.global().asyncAfter(deadline: .now() + delay) { send() }
+                    
+                    return
+                }
+                
                 do
                 {
-                    guard let data = data else { throw error ?? ALTAppleAPIError.unknown() }
+                    let responseDictionary = try self.propertyListResponse(data: data, response: response, error: error)
                     
-                    guard let responseDictionary = try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any],
-                          let dictionary = responseDictionary["Response"] as? [String: Any],
+                    guard let dictionary = responseDictionary["Response"] as? [String: Any],
                           let status = dictionary["Status"] as? [String: Any]
-                    else { throw URLError(.badServerResponse) }
+                    else { throw self.badServerResponseError(data: data, response: response, underlyingError: nil) }
                                         
                     let errorCode = status["ec"] as? Int ?? 0
                     guard errorCode != 0 else { return completionHandler(.success(dictionary)) }
@@ -477,6 +577,9 @@ private extension ALTAppleAPI
             }
             
             dataTask.resume()
+            }
+            
+            send()
         }
         catch
         {


### PR DESCRIPTION
Same fix as #49, ported to `notarized`.

`marketplace` and `notarized` have diverged and neither contains the other, so #49 does not reach anyone on the classic branches. AltStore's `classic` (AltServer 1.8b1, AltStore 2.3b2) and `classic_v2.3b1` both pin `db8e0eb` here, so this is the side that reaches AltServer and non EU AltStore users.

Reported in altstoreio/AltStore#1776, #1699, #1747.

## What happens

Sign in makes three calls to GsService2. Apple returns an HTML error page for some of them, and `sendAuthenticationRequest()` hands the body straight to `PropertyListSerialization` with no check, so a server error surfaces as `NSCocoaErrorDomain 3840 "Encountered unknown tag html on line 1"` and reads like bad credentials.

```
o=init       HTTP 200  text/x-xml-plist  ec=0
o=complete   HTTP 200  text/x-xml-plist  ec=0
o=apptokens  HTTP 503  text/html   <html>503 Service Temporarily Unavailable ... Apple</html>
```

Apple's edge also pins a connection to a backend node, and once that node starts failing every later request on the same connection fails too. `ALTAppleAPI` uses one session for everything, so all three calls share a connection and whichever request lands after it sours is the one that dies.

## Changes

Retry 5xx up to five times with backoff, each attempt on its own session so it opens a new connection. Retrying on the shared session does nothing, every attempt inherits the same dead node.

Report a failed parse as `NSURLErrorBadServerResponse` with the status, Content-Type and a body snippet instead of the raw 3840. `ALTAppleAPI.m` already does this for the other endpoints. The same helper covers the trusted device 2FA handler, which had the identical blind parse.

It parses first and only builds the better error on failure, rather than gating on the status code. A status check misses HTML served with a 200, and GSA reports its own status in the body as `Status.hsc`, so returning early could hide real error codes.

## Numbers

25 full sign in attempts per row, on an affected Mac:

```
                                   old UA    new UA
one shared connection (current)      2/25     19/25
fresh connection per request         0/25     18/25
fresh connection + retry on 5xx      5/25     25/25
```

The User-Agent matters more than anything else here. #47 fixes that on `marketplace`, but there is no equivalent for this branch yet, so `notarized` is still on the old UA even with this merged. Worth doing both.

## Testing

Verified on a Mac and iPhone that had both been failing:

1. AltServer built from `classic_v2.3b1` with this patch signed in first try and installed AltStore.
2. AltStore 2.3b1 built with this patch, sideloaded, refreshed apps fine where stock 2.2.1 failed every time.

Builds clean for iOS.
