### PR TITLE
Update GrandSlam authentication user agent (notarized line)

### DIFF
--- a/AltSign/Sources/ALTAppleAPI+Authentication.swift
+++ b/AltSign/Sources/ALTAppleAPI+Authentication.swift
@@ -436,7 +436,7 @@ private extension ALTAppleAPI
                 "Content-Type": "text/x-xml-plist",
                 "X-MMe-Client-Info": anisetteData.deviceDescription,
                 "Accept": "*/*",
-                "User-Agent": "akd/1.0 CFNetwork/978.0.7 Darwin/18.7.0"
+                "User-Agent": "AuthKit/1 (Macintosh; OS X 26.5.2) (com.apple.dt.Xcode/26.0)"
             ]
             
             let bodyData = try PropertyListSerialization.data(fromPropertyList: parameters, format: .xml, options: 0)


### PR DESCRIPTION
Port of #47 by @BreezeDelegate onto `notarized`. The change is theirs, this just applies it to the other branch, and the commit keeps them as author.

`marketplace` and `notarized` have diverged and neither contains the other. #47 targets `marketplace`, but AltStore's `classic` and `classic_v2.3b1` pin `notarized`, so AltServer and non EU AltStore builds do not get it. Without this they stay on the 2018 User-Agent.

## Why it matters

Apple's GSA edge allows a fixed number of requests per connection before it starts returning 503, and the User-Agent changes that number. Six requests down one reused connection, five trials each, identical every time:

```
old  akd/1.0 CFNetwork/978.0.7 Darwin/18.7.0        200 200 503 503 503 503
new  AuthKit/1 (Macintosh; OS X 26.5.2) (...26.0)   200 200 200 200 503 503
```

Two requests on the old string, four on the new one. `authenticate()` sends three down a single connection, so the third one always fails, which is exactly the reported symptom: init and complete succeed, apptokens returns an HTML 503, and the plist parser reports it as `NSCocoaErrorDomain 3840 "Encountered unknown tag html on line 1"`.

Interleaved over 100 requests each, one at a time on fresh connections:

```
old  100 requests, 12x 503
new  100 requests,  0x 503
```

## Scope

This is the whole fix for the deterministic part. There is a separate baseline failure of roughly 20 to 25 percent even on a fresh connection's first request, which the User-Agent does not affect (old 15/20, new 16/20). #50 handles that by retrying 5xx on a fresh connection. The two together got a machine that had never completed sign in to 25/25.

Reported in altstoreio/AltStore#1776, #1699, #1747.
