### PR TITLE
Use a separate connection for each GrandSlam request

### DIFF
--- a/AltSign/Sources/ALTAppleAPI+Authentication.swift
+++ b/AltSign/Sources/ALTAppleAPI+Authentication.swift
@@ -460,6 +460,14 @@ private extension ALTAppleAPI
                 {
                     guard let data = data else { throw error ?? ALTAppleAPIError.unknown() }
                     
+                    // Surface server errors directly; their HTML bodies are not property lists, and
+                    // parsing them yields a misleading "data couldn't be read" error instead.
+                    if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode >= 500
+                    {
+                        let message = String(format: NSLocalizedString("Apple's authentication servers returned an error (HTTP %d). This is a problem on Apple's end, not with your Apple ID or password.", comment: ""), httpResponse.statusCode)
+                        throw NSError(domain: ALTUnderlyingAppleAPIErrorDomain, code: httpResponse.statusCode, userInfo: [NSLocalizedDescriptionKey: message])
+                    }
+                    
                     guard let responseDictionary = try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any],
                           let dictionary = responseDictionary["Response"] as? [String: Any],
                           let status = dictionary["Status"] as? [String: Any]

--- a/AltSign/Sources/ALTAppleAPI+Authentication.swift
+++ b/AltSign/Sources/ALTAppleAPI+Authentication.swift
@@ -446,7 +446,16 @@ private extension ALTAppleAPI
             request.httpBody = bodyData
             httpHeaders.forEach { request.addValue($0.value, forHTTPHeaderField: $0.key) }
             
-            let dataTask = self.session.dataTask(with: request) { (data, response, error) in
+            // Apple's edge serves at most two requests per connection and answers every request
+            // after that with a 503 HTML error page. Authenticating takes three requests (init,
+            // complete, apptokens), so the third one fails whenever they share a pooled connection.
+            // Give each request its own session, and therefore its own connection.
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.httpMaximumConnectionsPerHost = 1
+            let session = URLSession(configuration: configuration)
+            defer { session.finishTasksAndInvalidate() }
+            
+            let dataTask = session.dataTask(with: request) { (data, response, error) in
                 do
                 {
                     guard let data = data else { throw error ?? ALTAppleAPIError.unknown() }


### PR DESCRIPTION
Signing in has been failing since roughly 2026-08-31 with `NSCocoaErrorDomain 3840`, "The data couldn't be read because it isn't in the correct format."

### Cause

Apple's edge in front of `gsa.apple.com` now serves at most **two requests per connection** and answers everything after that with a 503 HTML error page.

Authenticating takes three requests, and `URLSession` sends them over one pooled connection:

```
o=init       200
o=complete   200   ec=0  hsc=200      <- password accepted
o=apptokens  503   <html>503 Service Temporarily Unavailable ... Apple</html>
```

The password is accepted; only the token exchange fails. The 503's HTML body is then parsed as a property list, which is where the 3840 error comes from — the message describes the parser, not the failure.

The 503 is generated at the edge rather than by GrandSlam: successful responses carry `Content-Type: text/x-xml-plist` and `X-Apple-I-Retry-Request-UUID`, while the 503 has `Content-Type: text/html` and neither.

### Reproducing

Any POST body works, valid or not — only the position in the connection matters:

```sh
# 3rd request on a reused connection 503s; the first two do not
curl --http1.1 -w 'http=%{http_code}\n' -o /dev/null \
  -X POST -H 'Content-Type: text/x-xml-plist' --data-binary @body.plist \
  https://gsa.apple.com/grandslam/GsService2 \
  --next -w 'http=%{http_code}\n' -o /dev/null \
  -X POST -H 'Content-Type: text/x-xml-plist' --data-binary @body.plist \
  https://gsa.apple.com/grandslam/GsService2 \
  --next -w 'http=%{http_code}\n' -o /dev/null \
  -X POST -H 'Content-Type: text/x-xml-plist' --data-binary @body.plist \
  https://gsa.apple.com/grandslam/GsService2

# http=200
# http=200
# http=503
```

The same request on a fresh connection returns 200. Retrying does not help, because the retry reuses the same pooled connection.

### Changes

1. **Use a separate connection for each GrandSlam request.** Each request gets its own ephemeral session, so `apptokens` arrives first on a fresh connection.
2. **Report 5xx responses instead of failing to parse them.** The status code is currently never checked, so any server error surfaces as a parse failure. This is independent of the first commit and useful on its own.

Verified end to end against a real Apple ID: `init` → `complete` → `apptokens` all return 200, and sign-in and refresh work again on both AltServer and on-device AltStore.

This looks like the cause behind the recent reports in altstoreio/AltStore#1776, #1777, #1781, #1782 and SideStore/SideStore#1459, #1464, #1465, which are all the same 3840 error.

Targeting `notarized` since that is what AltStore Classic pins; `marketplace` compiles the SRP paths out.
