### PR TITLE
Preserve Apple errors while retrying transient GrandSlam failures

### DIFF
--- a/AltSign/Sources/ALTAppleAPI+Authentication.swift
+++ b/AltSign/Sources/ALTAppleAPI+Authentication.swift
@@ -436,7 +436,7 @@ private extension ALTAppleAPI
                 "Content-Type": "text/x-xml-plist",
                 "X-MMe-Client-Info": anisetteData.deviceDescription,
                 "Accept": "*/*",
-                "User-Agent": "akd/1.0 CFNetwork/978.0.7 Darwin/18.7.0"
+                "User-Agent": "AuthKit/1 (Macintosh; OS X 26.5.2) (com.apple.dt.Xcode/26.0)"
             ]
             
             let bodyData = try PropertyListSerialization.data(fromPropertyList: parameters, format: .xml, options: 0)
@@ -445,45 +445,92 @@ private extension ALTAppleAPI
             request.httpMethod = "POST"
             request.httpBody = bodyData
             httpHeaders.forEach { request.addValue($0.value, forHTTPHeaderField: $0.key) }
-            
-            let dataTask = self.session.dataTask(with: request) { (data, response, error) in
-                do
-                {
-                    guard let data = data else { throw error ?? ALTAppleAPIError.unknown() }
-                    
-                    guard let responseDictionary = try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any],
-                          let dictionary = responseDictionary["Response"] as? [String: Any],
-                          let status = dictionary["Status"] as? [String: Any]
-                    else { throw URLError(.badServerResponse) }
-                                        
-                    let errorCode = status["ec"] as? Int ?? 0
-                    guard errorCode != 0 else { return completionHandler(.success(dictionary)) }
-                    
-                    switch errorCode
-                    {
-                    case -20101, -22406: throw ALTAppleAPIError(.incorrectCredentials)
-                    case -22421: throw ALTAppleAPIError(.invalidAnisetteData)
-                    default:
-                        guard let errorDescription = status["em"] as? String else { throw ALTAppleAPIError.unknown() }
-                        
-                        let localizedDescription = errorDescription + " (\(errorCode))"
-                        throw NSError(domain: ALTUnderlyingAppleAPIErrorDomain, code: errorCode, userInfo: [NSLocalizedDescriptionKey: localizedDescription])
-                    }
-                }
-                catch
-                {
-                    completionHandler(.failure(error))
-                }
-            }
-            
-            dataTask.resume()
+
+            self.sendGrandSlamRequest(request, attempt: 1, deadline: ProcessInfo.processInfo.systemUptime + 20, completionHandler: completionHandler)
         }
         catch
         {
             completionHandler(.failure(error))
         }
     }
-    
+
+    // Isolate every GSA attempt and keep transient server retries within this exchange's deadline.
+    func sendGrandSlamRequest(_ request: URLRequest, attempt: Int, deadline: TimeInterval,
+                             completionHandler: @escaping (Result<[String: Any], Error>) -> Void)
+    {
+        let remaining = deadline - ProcessInfo.processInfo.systemUptime
+        guard remaining > 0 else {
+            completionHandler(.failure(URLError(.timedOut)))
+            return
+        }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = remaining
+        configuration.timeoutIntervalForResource = remaining
+        let session = URLSession(configuration: configuration)
+        var timedRequest = request
+        timedRequest.timeoutInterval = remaining
+
+        let dataTask = session.dataTask(with: timedRequest) { (data, response, error) in
+            session.finishTasksAndInvalidate()
+            do
+            {
+                if let error = error { throw error }
+                let httpResponse = response as? HTTPURLResponse
+
+                // Read structured Apple errors before considering a retry. Never expose response bodies.
+                let propertyList = data.flatMap { try? PropertyListSerialization.propertyList(from: $0, format: nil) }
+                let responseDictionary = propertyList as? [String: Any]
+                let dictionary = responseDictionary?["Response"] as? [String: Any]
+                let status = dictionary?["Status"] as? [String: Any]
+                if let errorCode = status?["ec"] as? Int, errorCode != 0
+                {
+                    switch errorCode
+                    {
+                    case -20101, -22406: throw ALTAppleAPIError(.incorrectCredentials)
+                    case -22421: throw ALTAppleAPIError(.invalidAnisetteData)
+                    default:
+                        guard let errorDescription = status?["em"] as? String else { throw ALTAppleAPIError.unknown() }
+
+                        let localizedDescription = errorDescription + " (\(errorCode))"
+                        throw NSError(domain: ALTUnderlyingAppleAPIErrorDomain, code: errorCode, userInfo: [NSLocalizedDescriptionKey: localizedDescription])
+                    }
+                }
+
+                // GSA carries its own status in the plist, including authentication challenges.
+                if let dictionary = dictionary, status != nil {
+                    completionHandler(.success(dictionary))
+                    return
+                }
+
+                if let httpResponse = httpResponse, (500...599).contains(httpResponse.statusCode), attempt < 5
+                {
+                    let delay = pow(2.0, Double(attempt - 1)) // Four retries: 1, 2, 4, then 8 seconds.
+                    if ProcessInfo.processInfo.systemUptime + delay < deadline
+                    {
+                        DispatchQueue.global().asyncAfter(deadline: .now() + delay) {
+                            self.sendGrandSlamRequest(request, attempt: attempt + 1, deadline: deadline, completionHandler: completionHandler)
+                        }
+                        return
+                    }
+                }
+
+                let message: String
+                if let httpResponse = httpResponse {
+                    message = String(format: NSLocalizedString("Apple's authentication servers returned an unexpected response (HTTP %ld). Please try again.", comment: ""), httpResponse.statusCode)
+                } else {
+                    message = NSLocalizedString("Apple's authentication servers returned an unexpected response. Please try again.", comment: "")
+                }
+                throw URLError(.badServerResponse, userInfo: [NSLocalizedDescriptionKey: message])
+            }
+            catch
+            {
+                completionHandler(.failure(error))
+            }
+        }
+        dataTask.resume()
+    }
+
     func makeTwoFactorCodeRequest(url: URL,
                                   dsid: String,
                                   idmsToken: String,

--- a/Tests/GrandSlamTransport/README.md
+++ b/Tests/GrandSlamTransport/README.md
@@ -1,0 +1,28 @@
+# GrandSlam transport regression tests
+
+Run on macOS with Python 3 and Xcode command-line tools:
+
+```sh
+python3 Tests/GrandSlamTransport/test_transport.py
+```
+
+To retain machine-readable results:
+
+```sh
+python3 Tests/GrandSlamTransport/test_transport.py --results /tmp/altsign-gsa-results.json
+```
+
+The runner extracts `sendAuthenticationRequest` and `sendGrandSlamRequest` directly from the production Swift file, replacing only the GSA endpoint with an ephemeral loopback HTTP server. Minimal type shims avoid needing SRP, accounts, signing certificates, or the complete application. A test-only URLProtocol injects cancellation/offline failures into otherwise normal ephemeral sessions. Compilation and execution happen in a temporary directory.
+
+The 17 cases cover:
+
+- HTML 503 followed by a valid plist, using a separate connection for each attempt.
+- Persistent 503: five total attempts, 1/2/4/8-second backoff, and the exchange deadline.
+- Structured success and authentication challenges on HTTP 409/503, including a missing `ec` field, preserving existing GSA semantics.
+- Incorrect credentials, invalid anisette, and arbitrary Apple error codes without retries, including structured errors returned with HTTP 503.
+- Malformed HTML with HTTP 200/401 and unexpected plist shapes, without response-body or underlying parser-error leakage.
+- Cancellation and offline errors without transport-helper retries.
+- In-flight timeout, insufficient retry budget, and an already-expired deadline.
+- Exactly one observed completion for each case and the modern User-Agent on GSA requests.
+
+This is transport regression coverage on macOS Foundation. It does not perform live SRP, submit a two-factor code, validate an Apple account, prove the User-Agent's effect at Apple's edge, or replace iPhone installation/refresh testing. Timing checks assume a reasonably unloaded development machine. No Apple account, certificate, or network service beyond loopback is used.

--- a/Tests/GrandSlamTransport/test_transport.py
+++ b/Tests/GrandSlamTransport/test_transport.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Exercise the production GSA transport against local, credential-free fixtures.
+
+Requires macOS, Python 3, and Xcode command-line tools. No Apple service is called.
+"""
+from pathlib import Path
+import argparse
+import http.server
+import threading
+import plistlib
+import subprocess
+import json
+import time
+import tempfile
+
+if not __debug__:
+    raise RuntimeError('Run this regression test without Python optimization (-O).')
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--results', type=Path, help='Optional JSON result file')
+args = parser.parse_args()
+repo = Path(__file__).resolve().parents[2]
+rel = 'AltSign/Sources/ALTAppleAPI+Authentication.swift'
+workspace = tempfile.TemporaryDirectory(prefix='altsign-gsa-test-')
+base = Path(workspace.name)
+records = []
+lock = threading.Lock()
+counts = {}
+connections = 0
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'
+
+    def setup(self):
+        global connections
+        super().setup()
+        with lock:
+            connections += 1
+            self.number = connections
+
+    def log_message(self, *args):
+        pass
+
+    def do_POST(self):
+        request = plistlib.loads(self.rfile.read(int(self.headers['Content-Length'])))
+        case = request['Request']['case']
+        with lock:
+            counts[case] = counts.get(case, 0) + 1
+            n = counts[case]
+            records.append({'case': case, 'attempt': n, 'connection': self.number, 'time': time.monotonic(), 'ua': self.headers.get('User-Agent')})
+        status = 200
+        payload = {'Response': {'Status': {'ec': 0}}}
+        body = None
+        if case == 'recover' and n == 1:
+            status = 503
+            body = b'<html>PRIVATE_MARKER</html>'
+        elif case == 'persistent':
+            status = 503
+            body = b'<html>PRIVATE_MARKER</html>'
+        elif case == 'structured503':
+            status = 503
+            payload = {'Response': {'Status': {'ec': -20101, 'em': 'Incorrect fixture credentials'}}}
+        elif case == 'challenge409':
+            status = 409
+            payload = {'Response': {'Status': {'ec': 0, 'au': 'trustedDeviceSecondaryAuth'}}}
+        elif case == 'success503':
+            status = 503
+        elif case == 'missingCode409':
+            status = 409
+            payload = {'Response': {'Status': {'au': 'secondaryAuth'}}}
+        elif case == 'structured200':
+            payload = {'Response': {'Status': {'ec': -22406, 'em': 'Incorrect fixture credentials'}}}
+        elif case == 'anisette503':
+            status = 503
+            payload = {'Response': {'Status': {'ec': -22421, 'em': 'Invalid fixture anisette'}}}
+        elif case == 'apple503':
+            status = 503
+            payload = {'Response': {'Status': {'ec': -12345, 'em': 'Fixture Apple error'}}}
+        elif case == 'html200':
+            body = b'<html>PRIVATE_MARKER</html>'
+        elif case == 'html401':
+            status = 401
+            body = b'<html>PRIVATE_MARKER</html>'
+        elif case == 'array200':
+            payload = ['PRIVATE_MARKER']
+        elif case == 'timeout':
+            time.sleep(1)
+        elif case == 'shortBudget':
+            status = 503
+            body = b'<html>PRIVATE_MARKER</html>'
+        if body is None:
+            body = plistlib.dumps(payload)
+            ct = 'text/x-xml-plist'
+        else:
+            ct = 'text/html'
+        try:
+            self.send_response(status)
+            self.send_header('Content-Type', ct)
+            self.send_header('Content-Length', str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
+server = http.server.ThreadingHTTPServer(('127.0.0.1', 0), Handler)
+
+threading.Thread(target=server.serve_forever, daemon=True).start()
+
+header='''import Foundation
+struct ALTAnisetteData { let deviceDescription: String }
+let ALTUnderlyingAppleAPIErrorDomain = "Fixture.AppleAPI"
+struct ALTAppleAPIError: Error {
+    enum Code: Int { case incorrectCredentials = 1, invalidAnisetteData = 2 }
+    let code: Code
+    init(_ code: Code) { self.code = code }
+    static func unknown() -> Error { NSError(domain: "Fixture", code: -1) }
+}
+final class FailingProtocol: URLProtocol {
+    static var calls = 0
+    override class func canInit(with request: URLRequest) -> Bool { request.url?.host == "fixture.invalid" }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        Self.calls += 1
+        let response = HTTPURLResponse(url: request.url!, statusCode: 503, httpVersion: "HTTP/1.1", headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        let code: URLError.Code = request.url!.path == "/cancel" ? .cancelled : .notConnectedToInternet
+        client?.urlProtocol(self, didFailWithError: URLError(code))
+    }
+    override func stopLoading() {}
+}
+// Inject only the offline/cancellation fixture protocol into otherwise normal ephemeral sessions.
+enum URLSessionConfiguration {
+    static var ephemeral: Foundation.URLSessionConfiguration {
+        let configuration = Foundation.URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [FailingProtocol.self] + (configuration.protocolClasses ?? [])
+        return configuration
+    }
+}
+class ALTAppleAPI {
+'''
+
+footer='''}
+_ = URLProtocol.registerClass(FailingProtocol.self)
+let api = ALTAppleAPI()
+let port = CommandLine.arguments[1]
+let cases = ["recover", "persistent", "challenge409", "success503", "missingCode409", "structured503", "structured200", "anisette503", "apple503", "html200", "html401", "array200", "cancel", "network", "timeout", "shortBudget", "expired"]
+var reports = [[String: Any]]()
+for name in cases {
+    let signal = DispatchSemaphore(value: 0)
+    let lock = NSLock()
+    var completions = 0
+    var report: [String: Any] = ["case": name]
+    let start = ProcessInfo.processInfo.systemUptime
+    let callback: (Result<[String: Any], Error>) -> Void = { result in
+        lock.lock()
+        completions += 1
+        switch result {
+        case .success: report["result"] = "success"
+        case .failure(let error):
+            if let apple = error as? ALTAppleAPIError {
+                report["result"] = "error"; report["domain"] = "Fixture.TypedAppleAPI"; report["code"] = apple.code.rawValue
+            } else {
+                let ns = error as NSError
+                report["result"] = "error"; report["domain"] = ns.domain; report["code"] = ns.code; report["message"] = ns.localizedDescription
+                report["hasUnderlyingError"] = ns.userInfo[NSUnderlyingErrorKey] != nil
+                assert(!String(describing: ns.userInfo).contains("PRIVATE_MARKER"), "response body leaked")
+            }
+        }
+        lock.unlock()
+        signal.signal()
+    }
+    if ["cancel", "network", "timeout", "shortBudget", "expired"].contains(name) {
+        let url = ["cancel", "network"].contains(name) ? URL(string: "http://fixture.invalid/\\(name)")! : URL(string: "http://127.0.0.1:\\(port)/GsService2")!
+        var request = URLRequest(url: url); request.httpMethod = "POST"
+        request.httpBody = try! PropertyListSerialization.data(fromPropertyList: ["Request": ["case": name]], format: .xml, options: 0)
+        let budget: TimeInterval = name == "expired" ? -1 : (name == "timeout" || name == "shortBudget" ? 0.5 : 20)
+        api.sendGrandSlamRequest(request, attempt: 1, deadline: start + budget, completionHandler: callback)
+    } else {
+        api.sendAuthenticationRequest(parameters: ["case": name], anisetteData: ALTAnisetteData(deviceDescription: "fixture"), completionHandler: callback)
+    }
+    assert(signal.wait(timeout: .now() + 23) == .success, "deadline/completion failure")
+    Thread.sleep(forTimeInterval: 0.05)
+    lock.lock(); report["completions"] = completions; report["elapsed"] = ProcessInfo.processInfo.systemUptime - start; lock.unlock()
+    assert(completions == 1)
+    reports.append(report)
+}
+assert(FailingProtocol.calls == 2, "transport fixture count: \\(FailingProtocol.calls)")
+let encoded = try! JSONSerialization.data(withJSONObject: reports, options: [.sortedKeys])
+print(String(data: encoded, encoding: .utf8)!)
+'''
+
+try:
+    source = (repo / rel).read_text()
+    start = source.index('    func sendAuthenticationRequest(')
+    end = source.index('    func makeTwoFactorCodeRequest(', start)
+    method = source[start:end]
+    assert method.count('https://gsa.apple.com/grandslam/GsService2') == 1
+    method = method.replace('https://gsa.apple.com/grandslam/GsService2', f'http://127.0.0.1:{server.server_port}/GsService2')
+    path = base / 'retries.swift'
+    path.write_text(header + method + footer)
+    compile = subprocess.run(['xcrun', 'swiftc', '-swift-version', '5', '-module-cache-path', str(base / 'module-cache'), str(path), '-o', str(base / 'retries')], capture_output=True, text=True)
+    if compile.returncode:
+        raise RuntimeError(compile.stderr)
+    print('COMPILE PASS: production methods with only the destination replaced by a local fixture.', flush=True)
+    if compile.stderr:
+        print(compile.stderr, flush=True)
+    run = subprocess.run([str(base / 'retries'), str(server.server_port)], capture_output=True, text=True, timeout=45)
+    if run.returncode:
+        raise RuntimeError(run.stderr + run.stdout)
+    results = json.loads(run.stdout)
+    by = {r['case']: r for r in results}
+    for r in results:
+        assert r['completions'] == 1
+    assert by['recover']['result'] == 'success' and counts['recover'] == 2
+    for name in ['challenge409', 'success503', 'missingCode409']:
+        assert by[name]['result'] == 'success' and counts[name] == 1
+    assert by['persistent']['code'] == -1011 and counts['persistent'] == 5 and (15 <= by['persistent']['elapsed'] < 20)
+    p = [r for r in records if r['case'] == 'persistent']
+    gaps = [p[i + 1]['time'] - p[i]['time'] for i in range(4)]
+    for (expected, actual) in zip([1, 2, 4, 8], gaps):
+        assert expected <= actual < expected + 1, (expected, actual)
+    assert len({r['connection'] for r in records}) == len(records), 'session connection reused'
+    for (name, code) in [('structured503', 1), ('structured200', 1), ('anisette503', 2)]:
+        assert by[name]['domain'] == 'Fixture.TypedAppleAPI' and by[name]['code'] == code and (counts[name] == 1)
+    assert by['apple503']['domain'] == 'Fixture.AppleAPI' and by['apple503']['code'] == -12345 and (by['apple503']['message'] == 'Fixture Apple error (-12345)') and (counts['apple503'] == 1)
+    for name in ['html200', 'html401', 'array200']:
+        assert by[name]['code'] == -1011 and counts[name] == 1 and (not by[name]['hasUnderlyingError'])
+    for (name, code) in [('cancel', -999), ('network', -1009)]:
+        assert by[name]['domain'] == 'NSURLErrorDomain' and by[name]['code'] == code
+    assert by['timeout']['code'] == -1001 and counts['timeout'] == 1 and (by['timeout']['elapsed'] < 1)
+    assert by['shortBudget']['code'] == -1011 and counts['shortBudget'] == 1 and (by['shortBudget']['elapsed'] < 1)
+    assert by['expired']['code'] == -1001 and counts.get('expired', 0) == 0
+    modern = 'AuthKit/1 (Macintosh; OS X 26.5.2) (com.apple.dt.Xcode/26.0)'
+    assert all((r['ua'] == modern for r in records if r['case'] not in ['timeout', 'shortBudget']))
+    output = {'cases': results, 'requests': records, 'persistentRetryGaps': gaps}
+    if args.results:
+        args.results.write_text(json.dumps(output, indent=2) + '\n')
+    print(json.dumps(results, indent=2))
+    print('PASS: 17 production-method scenarios; fresh connections, exact backoff, five attempts, deadline/timeouts, structured Apple errors, cancellation/network passthrough, malformed-body redaction, completion once.')
+finally:
+    server.shutdown()
+    server.server_close()
+    workspace.cleanup()


### PR DESCRIPTION
## Summary

GrandSlam sometimes returns an HTML error page during Apple ID sign-in. AltSign feeds that page to the property-list parser, so a transport/server failure appears as `NSCocoaErrorDomain 3840` / `Encountered unknown tag html`. This change uses the modern AuthKit User-Agent and an isolated session for each GSA attempt, adds bounded recovery for unstructured HTTP 5xx responses, and preserves Apple's structured protocol results before considering retries.

This is a source-and-tests contribution against **`notarized`**, the line used by AltStore Classic. The companion [AltStore integration PR #1786](https://github.com/altstoreio/AltStore/pull/1786) consumes this dependency change.

## Background

### Existing work and why this proposal exists

This builds on existing investigations, rather than claiming the original discovery:

- BreezeDelegate's [User-Agent proposal #47](https://github.com/rileytestut/AltSign/pull/47), and Calvin-Zikakis's [notarized port #51](https://github.com/rileytestut/AltSign/pull/51).
- Calvin-Zikakis's [retry proposal #49](https://github.com/rileytestut/AltSign/pull/49) and [notarized counterpart #50](https://github.com/rileytestut/AltSign/pull/50).
- sshane's [per-request session proposal #52](https://github.com/rileytestut/AltSign/pull/52).
- CircuitSerein's [connection-reuse investigation in AltStore #1782](https://github.com/altstoreio/AltStore/issues/1782#issuecomment-5558494372).

The additional reviewable pieces here are a **monotonic time budget**, **protocol-result precedence over HTTP status**, **body-free error handling**, and **17 executable regression scenarios**. If maintainers prefer to fold these changes into #50/#51/#52 rather than merge another proposal, that would also address the goal. The existing proposals are still open; this PR does not imply they were merged or authored here.

### Failure mechanism and evidence

The sign-in sequence sends SRP `init`, SRP `complete`, and `apptokens` requests through `sendAuthenticationRequest`. The original investigation observed a reused connection return two plist responses followed by an HTML 503. A later real installation attempt also produced a 503 after the per-request-session workaround was already installed. That latter observation is why this contribution adds bounded retries instead of assuming isolation alone guarantees success.

A local, credential-free HTTP/1.1 fixture independently reproduced the original failure: its first two requests on a connection return valid plists and subsequent requests return HTML 503. The original production method failed on the third exchange with Cocoa error 3840; the isolated-session method completed all three exchanges on separate connections. This proves the client behavior under that failure condition; it does not claim knowledge of Apple's internal load-balancer implementation or a universal two-request limit.

## Changes

### Isolate GSA transport and bound recovery

`sendAuthenticationRequest` continues to construct the same request body and headers, with the GSA User-Agent changed to the value proposed in #47. It delegates execution to a private `sendGrandSlamRequest` helper.

Each attempt:

1. Checks the remaining time against a deadline based on `ProcessInfo.systemUptime`.
2. Creates a fresh ephemeral URLSession and applies the remaining budget to both session timeout settings and the request timeout.
3. Explicitly invalidates the session when its task completes.
4. Returns transport errors immediately.
5. Interprets a valid `Response.Status` plist using the existing Apple error/success semantics.
6. Only if there is no usable structured protocol result, considers an HTTP 500–599 retry.

The policy is **five total attempts**, with delays of **1, 2, 4, and 8 seconds**, constrained by **20 seconds per GSA exchange**. A retry is not scheduled if its delay would exhaust the budget. This deadline is a deliberate operational bound, not a claim about the undocumented lifetime of anisette data; maintainer input on the budget is welcome.

### Preserve protocol results

A structured Apple result takes precedence over the HTTP envelope. This preserves existing behavior for success and authentication challenges, including HTTP 409 with `ec = 0`, and avoids retrying real credential or anisette failures returned inside HTTP 503.

Existing mappings remain intact:

| Result | Behavior |
|---|---|
| `-20101` / `-22406` | Existing incorrect-credentials error; no retry |
| `-22421` | Existing invalid-anisette error; no retry |
| Other nonzero `ec` with `em` | Existing Apple error domain, code, and message; no retry |
| Valid `Response.Status` with zero or absent `ec` | Existing successful protocol result, including challenge fields |
| Unstructured HTTP 500–599 | Retry within the attempt/time limits |
| Cancellation, offline/network error, 4xx, malformed HTTP 200 | Return an error without helper retries |

The SRP payloads, key derivation, anisette generation, developer-portal requests, and two-factor code submission flows are unchanged. A 5xx response is **not** assumed to prove that Apple did not process the request.

### Avoid leaking error-page contents

When an unusable response cannot be recovered, the user receives `URLError.badServerResponse` with the HTTP status when available. Neither the response body nor the property-list parser's underlying error is included. This avoids both the misleading format-error message and accidental disclosure of body content through an error object.

## Testing

Added:

- `Tests/GrandSlamTransport/test_transport.py`
- `Tests/GrandSlamTransport/README.md`

Run on macOS with Python 3 and Xcode command-line tools:

```sh
python3 Tests/GrandSlamTransport/test_transport.py
```

The harness extracts the production Swift methods, changes only the endpoint to loopback, and compiles them with minimal model/error shims. A test-only URLProtocol injects cancellation and offline failures. No Apple account, certificate, password, verification code, or external authentication endpoint is used.

**Result: all 17 scenarios passed.** The persistent-503 case made exactly five attempts over approximately 16.1 seconds, within the 20-second budget. All fixture requests used separate connections, and every case observed one completion.

Coverage includes 503 recovery/exhaustion, 1/2/4/8 backoff, structured Apple errors on both 200 and 503, challenges/success on non-2xx responses, malformed HTML/array responses, cancellation/offline passthrough, in-flight timeout, insufficient/expired budgets, modern User-Agent, and absence of body/parser-error leakage. The global staged-file Semgrep and high-severity Bandit checks also passed.

### Verification boundary

- The equivalent production transport was built into both a local macOS AltServer and AltStore 2.2.1 (48) for iPhone during the recovery.
- After applying the separately documented signing/UI compatibility steps, the reporter confirmed that AltStore opens, signs in, installs apps, and refreshes apps on an iPhone 15 Pro running iOS 27.0, using an Apple Silicon Mac on macOS 26.5.2.
- The complete authentication source in this PR is byte-for-byte identical to the source in the device-validated recovery build (SHA-256 `27f118687765b51fec0085d730d49b51943042624752c05ed084314ad7a388e6`). The final PR source also has a fresh passing transport-suite run. This fixture tests macOS Foundation transport behavior, not live SRP or the actual numeric implementation of the shimmed error type.
- Standalone SwiftPM validation initially lacked ldid's OpenSSL framework search path. Supplying that path let source compilation proceed, but the final link lacked the `_alt_*` corecrypto symbols normally provided by the workspace's separately built crypto library. Neither attempt is counted as a passing standalone package build. The successful recovery application builds used the Xcode workspace setup.
- Windows, macOS 27 anisette generation, all account types, poor-network performance, and long-running refresh behavior have not been established by this test run.

## Additional Notes

### Deployment

AltSign is compiled into both sides of the Classic workflow. Rebuilding AltServer alone does not update the copy used by an existing iPhone installation. Consumers need coordinated Mac/iPhone builds and distribution of the patched iPhone IPA; otherwise the original format error can remain on-device.

This PR contains source and a local test harness only. It does not publish signed apps, signing identities, provisioning profiles, or raw device logs. It was prepared with AI assistance, reviewed against the production flow and upstream discussions, and validated with executed tests plus the reporter's explicit on-device confirmation.
